### PR TITLE
add 8k inode and 32m block analysis, resolve #25

### DIFF
--- a/pcircle/globals.py
+++ b/pcircle/globals.py
@@ -102,9 +102,9 @@ class G:
     #             "B5_001t_up"]
 
     # GPFS
-    gpfs_block_size = ("256k", "512k", "b1m", "b4m", "b8m", "b16m")
-    gpfs_block_cnt = [0, 0, 0, 0, 0, 0]
-    gpfs_subs = (b256k/32, b512k/32, b1m/32, b4m/32, b8m/32, b16m/32)
+    gpfs_block_size = ("256k", "512k", "b1m", "b4m", "b8m", "b16m", "b32m")
+    gpfs_block_cnt = [0, 0, 0, 0, 0, 0, 0]
+    gpfs_subs = (b256k/32, b512k/32, b1m/32, b4m/32, b8m/32, b16m/32, b32m/32)
 
     dev_suffixes = [".C", ".CC", ".CU", ".H", ".CPP", ".HPP", ".CXX", ".F", ".I", ".II",
                     ".F90", ".F95", ".F03", ".FOR", ".O", ".A", ".SO", ".S",


### PR DESCRIPTION
the inode size is now a command line argument, with string size form
such as "8k" or "16k", converted to a number internally. 32m is added.
For each inode size, we can only do one pass subblock analysis.